### PR TITLE
Remove warning, fix double free, bump version

### DIFF
--- a/lua_cmsgpack.c
+++ b/lua_cmsgpack.c
@@ -7,7 +7,7 @@
 #include "lua.h"
 #include "lauxlib.h"
 
-#define LUACMSGPACK_VERSION     "lua-cmsgpack 0.3.0"
+#define LUACMSGPACK_VERSION     "lua-cmsgpack 0.3.1"
 #define LUACMSGPACK_COPYRIGHT   "Copyright (C) 2012, Salvatore Sanfilippo"
 #define LUACMSGPACK_DESCRIPTION "MessagePack C implementation for Lua"
 
@@ -29,6 +29,7 @@
  * 20-Feb-2012 (ver 0.2.0): Tables encoding improved.
  * 20-Feb-2012 (ver 0.2.1): Minor bug fixing.
  * 20-Feb-2012 (ver 0.3.0): Module renamed lua-cmsgpack (was lua-msgpack).
+ * 04-Apr-2014 (ver 0.3.1): Lua 5.2 support and minor bug fix.
  * ============================================================================ */
 
 /* --------------------------- Endian conversion --------------------------------

--- a/rockspec/lua-cmsgpack-0.3-1.rockspec
+++ b/rockspec/lua-cmsgpack-0.3-1.rockspec
@@ -1,0 +1,25 @@
+package = "lua-cmsgpack"
+version = "0.3.1-0"
+source = {
+   url = "git://github.com/antirez/lua-cmsgpack.git",
+   tag = "0.3.1"
+}
+description = {
+   summary = "MessagePack C implementation and bindings for Lua 5.1/5.2",
+   homepage = "http://github.com/antirez/lua-cmsgpack",
+   license = "Two-clause BSD",
+   maintainer = "Salvatore Sanfilippo <antirez@gmail.com>"
+}
+dependencies = {
+   "lua >= 5.1"
+}
+build = {
+   type = "builtin",
+   modules = {
+      cmsgpack = {
+         sources = {
+            "lua_cmsgpack.c",
+         }
+      }
+   }
+}


### PR DESCRIPTION
Four tiny fixes here:
- remove a compile-time warning so we don't see it when building Redis
- fix a double free (on error conditions)
- refactor version checking to allow future versions to work too
- bump version for easier inclusion in other projects
