### PR TITLE
use (signed char) instead of (char), this fixes for platforms that treat...

### DIFF
--- a/lua_cmsgpack.c
+++ b/lua_cmsgpack.c
@@ -220,7 +220,7 @@ static void mp_encode_int(mp_buf *buf, int64_t n) {
         }
     } else {
         if (n >= -32) {
-            b[0] = ((char)n);   /* negative fixnum */
+            b[0] = ((signed char)n);   /* negative fixnum */
             enclen = 1;
         } else if (n >= -128) {
             b[0] = 0xd0;        /* int 8 */
@@ -478,7 +478,7 @@ void mp_decode_to_lua_type(lua_State *L, mp_cur *c) {
         break;
     case 0xd0:  /* int 8 */
         mp_cur_need(c,2);
-        lua_pushnumber(L,(char)c->p[1]);
+        lua_pushnumber(L,(signed char)c->p[1]);
         mp_cur_consume(c,2);
         break;
     case 0xcd:  /* uint 16 */


### PR DESCRIPTION
On Android, char is interpreted as unsigned by default.

When decoding "int 8" format on Android, the following type conversion produces incorrect result: 
lua_pushnumber(L,(char)c->p[1]); // (e.g. -39 -> 217)

Changing (char) to (signed char) fixes this on Android and other platforms that treat char as unsigned by default.
