### PR TITLE
fix segfault when length fields contain a big 32-bit number

### DIFF
--- a/lua_cmsgpack.c
+++ b/lua_cmsgpack.c
@@ -542,6 +542,7 @@ static int mp_pack(lua_State *L) {
 void mp_decode_to_lua_type(lua_State *L, mp_cur *c);
 
 void mp_decode_to_lua_array(lua_State *L, mp_cur *c, size_t len) {
+    assert(len <= UINT_MAX);
     int index = 1;
 
     lua_newtable(L);
@@ -554,6 +555,7 @@ void mp_decode_to_lua_array(lua_State *L, mp_cur *c, size_t len) {
 }
 
 void mp_decode_to_lua_hash(lua_State *L, mp_cur *c, size_t len) {
+    assert(len <= UINT_MAX);
     lua_newtable(L);
     while(len--) {
         mp_decode_to_lua_type(L,c); /* key */
@@ -697,13 +699,14 @@ void mp_decode_to_lua_type(lua_State *L, mp_cur *c) {
     case 0xdb:  /* raw 32 */
         mp_cur_need(c,5);
         {
-            size_t l = (c->p[1] << 24) |
-                       (c->p[2] << 16) |
-                       (c->p[3] << 8) |
-                       c->p[4];
-            mp_cur_need(c,5+l);
-            lua_pushlstring(L,(char*)c->p+5,l);
-            mp_cur_consume(c,5+l);
+            size_t l = ((size_t)c->p[1] << 24) |
+                       ((size_t)c->p[2] << 16) |
+                       ((size_t)c->p[3] << 8) |
+                       (size_t)c->p[4];
+            mp_cur_consume(c,5);
+            mp_cur_need(c,l);
+            lua_pushlstring(L,(char*)c->p,l);
+            mp_cur_consume(c,l);
         }
         break;
     case 0xdc:  /* array 16 */
@@ -717,10 +720,10 @@ void mp_decode_to_lua_type(lua_State *L, mp_cur *c) {
     case 0xdd:  /* array 32 */
         mp_cur_need(c,5);
         {
-            size_t l = (c->p[1] << 24) |
-                       (c->p[2] << 16) |
-                       (c->p[3] << 8) |
-                       c->p[4];
+            size_t l = ((size_t)c->p[1] << 24) |
+                       ((size_t)c->p[2] << 16) |
+                       ((size_t)c->p[3] << 8) |
+                       (size_t)c->p[4];
             mp_cur_consume(c,5);
             mp_decode_to_lua_array(L,c,l);
         }
@@ -736,10 +739,10 @@ void mp_decode_to_lua_type(lua_State *L, mp_cur *c) {
     case 0xdf:  /* map 32 */
         mp_cur_need(c,5);
         {
-            size_t l = (c->p[1] << 24) |
-                       (c->p[2] << 16) |
-                       (c->p[3] << 8) |
-                       c->p[4];
+            size_t l = ((size_t)c->p[1] << 24) |
+                       ((size_t)c->p[2] << 16) |
+                       ((size_t)c->p[3] << 8) |
+                       (size_t)c->p[4];
             mp_cur_consume(c,5);
             mp_decode_to_lua_hash(L,c,l);
         }

--- a/test.lua
+++ b/test.lua
@@ -396,6 +396,12 @@ test_circular("regression for issue #4 circular",a)
 -- for each character in the string.  We don't care about the return value, just that we don't segfault.
 cmsgpack.unpack("82a17881a17882a17881a17882a17881a17882a17881a17882a17881a17882a17881a17882a17881a17882a17881a17")
 
+-- Test unpacking input which may cause overflow memory access ("-1" for 32-bit size fields).
+-- These should cause a Lua error but not a segfault.
+test_error("unpack big string with missing input", function() cmsgpack.unpack("\219\255\255\255\255Z") end)
+test_error("unpack big array with missing input", function() cmsgpack.unpack("\221\255\255\255\255Z") end)
+test_error("unpack big map with missing input", function() cmsgpack.unpack("\223\255\255\255\255Z") end)
+
 -- Tests from github.com/moteus
 test_circular("map with number keys", {[1] = {1,2,3}})
 test_circular("map with string keys", {["1"] = {1,2,3}})


### PR DESCRIPTION
When interpreting MessagePack 32-bit length fields, we incorrectly cast
to int; this causes a field length of "\xff\xff\xff\xff" to be
interpreted as -1, which is then casted to size_t as
18446744073709551615 (= max_uint64 - 1).

The fix makes sure that all the size arithmetic is done as size_t; and
prevents adding anything to a given size_t in order not to overflow
(even on 32-bit builds).

The customized problematic inputs appear in `test.lua`.

Note: this bug was found with the great automatic help of [american fuzzy lop](http://lcamtuf.coredump.cx/afl/) 0.89b. 
