### PR TITLE
Add isinf() if isinf() doesn't exist

### DIFF
--- a/lua_cmsgpack.c
+++ b/lua_cmsgpack.c
@@ -18,6 +18,11 @@
     #define LUACMSGPACK_MAX_NESTING  16 /* Max tables nesting. */
 #endif
 
+/* Workaround for Solaris platforms missing isinf() */
+#if !defined(isinf) && (defined(USE_INTERNAL_ISINF) || defined(MISSING_ISINF))
+#define isinf(x) (!isnan(x) && isnan((x) - (x)))
+#endif
+
 /* Check if float or double can be an integer without loss of precision */
 #define IS_INT_TYPE_EQUIVALENT(x, T) (!isinf(x) && (T)(x) == (x))
 


### PR DESCRIPTION
Fixes a build problem on Solaris.  Though, this fix depends on isnan() existing.

If this fix isn't enough, we should just copy solarisfixes.h from Redis here too.
